### PR TITLE
fix HTTPS下CSRF verification failed的问题

### DIFF
--- a/template/app_doc/docs_base.html
+++ b/template/app_doc/docs_base.html
@@ -8,7 +8,7 @@
     <meta http-equiv="Cache-Control" content="no-transform" />
     <meta http-equiv="Cache-Control" content="no-siteapp" />
     <meta http-equiv="Cache-Control" content="max-age=7200" />
-    <meta name="referrer" content="no-referrer">
+    <meta name="referrer" content="strict-origin">
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
     <meta name="keywords" content="{% block keyword %}{% endblock %}{{site_keywords}}"/>
     <meta name="description" content="{% block description %}{% endblock %}" />

--- a/template/app_doc/editor/create_base_2.html
+++ b/template/app_doc/editor/create_base_2.html
@@ -8,7 +8,7 @@
     <meta http-equiv="Cache-Control" content="no-transform" />
     <meta http-equiv="Cache-Control" content="no-siteapp" />
     <meta http-equiv="Cache-Control" content="max-age=7200" />
-    <meta name="referrer" content="no-referrer">
+    <meta name="referrer" content="strict-origin">
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
     <title>{% block title %}{% endblock %} - {% if site_name != None and site_name != '' %}{{site_name}} {% else %}站点标题{% endif %}</title>
     <link href="{% static 'layui/css/layui.css' %}?version={{mrdoc_version}}" rel="stylesheet">

--- a/template/app_doc/editor/create_base_vditor.html
+++ b/template/app_doc/editor/create_base_vditor.html
@@ -8,7 +8,7 @@
     <meta http-equiv="Cache-Control" content="no-transform" />
     <meta http-equiv="Cache-Control" content="no-siteapp" />
     <meta http-equiv="Cache-Control" content="max-age=7200" />
-    <meta name="referrer" content="no-referrer">
+    <meta name="referrer" content="strict-origin">
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
     <title>{% block title %}{% endblock %} - {% if site_name != None and site_name != '' %}{{site_name}} {% else %}站点标题{% endif %}</title>
     <link href="{% static 'layui/css/layui.css' %}?version={{mrdoc_version}}" rel="stylesheet">

--- a/template/app_doc/share/share_doc.html
+++ b/template/app_doc/share/share_doc.html
@@ -8,7 +8,7 @@
     <meta http-equiv="Cache-Control" content="no-transform" />
     <meta http-equiv="Cache-Control" content="no-siteapp" />
     <meta http-equiv="Cache-Control" content="max-age=7200" />
-    <meta name="referrer" content="no-referrer">
+    <meta name="referrer" content="strict-origin">
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
     <meta name="keywords" content="{% block keyword %}{% endblock %}{{site_keywords}}"/>
     <meta name="description" content="{% block description %}{% endblock %}" />

--- a/template/app_doc/tag_doc_base.html
+++ b/template/app_doc/tag_doc_base.html
@@ -8,7 +8,7 @@
     <meta http-equiv="Cache-Control" content="no-transform" />
     <meta http-equiv="Cache-Control" content="no-siteapp" />
     <meta http-equiv="Cache-Control" content="max-age=7200" />
-    <meta name="referrer" content="no-referrer">
+    <meta name="referrer" content="strict-origin">
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
     <meta name="keywords" content="{% if site_keywords != None %}{{site_keywords}}{% endif %}"/>
     <meta name="description" content="{% if site_desc != None %}{{site_desc}}{% endif %}" />


### PR DESCRIPTION
发现无法POST， Status Code: 403 Forbidden，具体提示如下： 
![image](https://user-images.githubusercontent.com/70483922/101928401-714ae400-3bcd-11eb-8aed-a024bb8ecc37.png)

> 
> Forbidden (403)
> CSRF verification failed. Request aborted.
> 
> You are seeing this message because this HTTPS site requires a 'Referer header' to be sent by your Web browser, but none was sent. This header is required for security reasons, to ensure that your browser is not being hijacked by third parties.
> 
> If you have configured your browser to disable 'Referer' headers, please re-enable them, at least for this site, or for HTTPS connections, or for 'same-origin' requests.
> 
> If you are using the <meta name="referrer" content="no-referrer"> tag or including the 'Referrer-Policy: no-referrer' header, please remove them. The CSRF protection requires the 'Referer' header to do strict referer checking. If you're concerned about privacy, use alternatives like <a rel="noreferrer" ...> for links to third-party sites.

