### PR TITLE
修复上传图片API的bug

### DIFF
--- a/app_api/views.py
+++ b/app_api/views.py
@@ -293,8 +293,9 @@ def upload_img(request):
     # {"success": 1, "url": "图片地址"}
     ##################
     token = request.GET.get('token', '')
-    base64_img = request.POST.get('data','')
+    #base64_img = request.POST.get('data','')
     try:
+        base64_img = json.loads(request.body.decode("ascii"))['data']
         # 验证Token
         token = UserToken.objects.get(token=token)
         # 上传图片

--- a/app_doc/util_upload_img.py
+++ b/app_doc/util_upload_img.py
@@ -222,13 +222,26 @@ def img_upload(files, dir_name, user, group_id=None):
     )
     return {"success": 1, "url": file_url,'message':_('上传图片成功')}
 
+# 解析image/png获取扩展名
+def getImageExtensionName(temps):
+    if len(temps) == 2:
+        #image/png
+        temps = temps[0].split('image/')
+        if len(temps) == 2:
+            ## 如果文件传了扩展名，就取扩展名的文件类型
+            if  temps[-1] != '':
+                return "." + temps[-1]
+    return ".png" 
 
 # base64编码图片上传
 def base_img_upload(files,dir_name, user):
-    files_str = files.split(';base64,')[-1] # 截取图片正文
+    temps = files.split(';base64,') # 截取图片正文
+    files_str = temps[-1] # 截取图片正文
+    extensionName = getImageExtensionName(temps)
+
     files_base = base64.b64decode(files_str) # 进行base64编码
     relative_path = upload_generation_dir(dir_name)
-    file_name = str(datetime.datetime.today()).replace(':', '').replace(' ', '_').split('.')[0] + '.png' # 日期时间
+    file_name = str(datetime.datetime.today()).replace(':', '').replace(' ', '_').split('.')[0] + extensionName # 日期时间
     path_file = os.path.join(relative_path, file_name)
     path_file = settings.MEDIA_ROOT + path_file
     # print('文件路径：', path_file)

--- a/app_doc/util_upload_img.py
+++ b/app_doc/util_upload_img.py
@@ -241,7 +241,7 @@ def base_img_upload(files,dir_name, user):
 
     files_base = base64.b64decode(files_str) # 进行base64编码
     relative_path = upload_generation_dir(dir_name)
-    file_name = str(datetime.datetime.today()).replace(':', '').replace(' ', '_').split('.')[0] + extensionName # 日期时间
+    file_name = str(datetime.datetime.today()).replace(':', '').replace(' ', '_').replace('.', '_') + extensionName # 日期时间
     path_file = os.path.join(relative_path, file_name)
     path_file = settings.MEDIA_ROOT + path_file
     # print('文件路径：', path_file)


### PR DESCRIPTION
目前使用API上传图片，图片无法打开。
![图片](https://user-images.githubusercontent.com/9709432/129433109-7e493447-5f0f-440c-87b5-aff9ef94f4dc.png)

查看目录发现图片大小为0

![图片](https://user-images.githubusercontent.com/9709432/129433113-32b28532-3d52-4f12-af9f-fe3b206c151c.png)

提交的url： http://127.0.0.1:8009/api/upload_img/?token=ad8a78e68deca70891b2b9f9a6ae0d91a5db8414a59fece535b43fbc
提交的数据：{"data":"image/png;base64,图片base64"}

检查代码发现，通过表单的方式读取`base64_img = request.POST.get('data','')`
实际这样获取不到的。需要从body读取后json解码。改为：`base64_img = json.loads(request.body.decode("ascii"))['data']`就可以获取到了。

另外优化：
1. 原来写死png格式，现在从image/png里面解析文件后缀。
2. 原来图片文件名精确到秒，容易造成批量上传图片时，名称重复，改为精确到微秒。