### PR TITLE
fix: prevent unauthorized project document access

### DIFF
--- a/app_api/tests.py
+++ b/app_api/tests.py
@@ -1,3 +1,44 @@
+from django.contrib.auth.models import User
 from django.test import TestCase
+from rest_framework.test import APIRequestFactory
 
-# Create your tests here.
+from app_api.views_app import DocView
+from app_doc.models import Doc, Project
+
+
+class DocViewPermissionTest(TestCase):
+    def setUp(self):
+        self.factory = APIRequestFactory()
+        self.owner = User.objects.create_user(username='owner', password='password')
+        self.public_project = Project.objects.create(
+            name='public',
+            intro='public project',
+            role=0,
+            create_user=self.owner,
+        )
+        self.private_project = Project.objects.create(
+            name='private',
+            intro='private project',
+            role=1,
+            create_user=self.owner,
+        )
+        self.private_doc = Doc.objects.create(
+            name='secret',
+            pre_content='secret',
+            content='secret content',
+            top_doc=self.private_project.id,
+            create_user=self.owner,
+        )
+
+    def test_doc_detail_requires_doc_to_belong_to_requested_project(self):
+        request = self.factory.get(
+            '/api_app/docs/',
+            {
+                'pid': self.public_project.id,
+                'did': self.private_doc.id,
+            },
+        )
+
+        response = DocView.as_view()(request)
+
+        self.assertEqual(response.data['code'], 4)

--- a/app_api/views_app.py
+++ b/app_api/views_app.py
@@ -20,6 +20,7 @@ from app_doc.models import *
 from app_api.serializers_app import *
 from app_api.auth_app import AppAuth,AppMustAuth
 from app_doc.views import validateTitle
+from app_doc.utils import can_view_project
 from app_doc.util_upload_img import img_upload,base_img_upload
 from loguru import logger
 import datetime
@@ -440,45 +441,20 @@ class DocView(APIView):
 
         # 存在文集ID和文档ID，进行数据库检索
         if pro_id != '' and doc_id != '':
-            # 获取文集信息
-            project = Project.objects.get(id=int(pro_id))
-            # 获取文集的协作用户信息
-            if request.auth:
-                colla_user = ProjectCollaborator.objects.filter(project=project, user=request.user)
-                if colla_user.exists():
-                    colla_user_role = colla_user[0].role
-                    colla_user = colla_user.count()
-                else:
-                    colla_user = colla_user.count()
-            else:
-                colla_user = 0
+            try:
+                # 获取文集信息
+                project = Project.objects.get(id=int(pro_id))
+            except (ValueError, ObjectDoesNotExist):
+                return Response({'code':4})
 
-            # 私密文集且访问者非创建者、协作者 - 不能访问
-            if (project.role == 1) and (request.user != project.create_user) and (colla_user == 0):
+            if not can_view_project(request, project):
+                if project.role == 3:
+                    return Response({'code':3})
                 return Response({'code':2})
-            # 指定用户可见文集
-            elif project.role == 2:
-                user_list = project.role_value
-                if request.user.is_authenticated:  # 认证用户判断是否在许可用户列表中
-                    if (request.user.username not in user_list) and \
-                            (request.user != project.create_user) and \
-                            (colla_user == 0):  # 访问者不在指定用户之中，也不是协作者
-                        return Response({'code': 2})
-                else:  # 游客直接返回404
-                    return Response({'code': 2})
-            # 访问码可见
-            elif project.role == 3:
-                # 浏览用户不为创建者和协作者 - 需要访问码
-                if (request.user != project.create_user) and (colla_user == 0):
-                    viewcode = project.role_value
-                    viewcode_name = 'viewcode-{}'.format(project.id)
-                    r_viewcode = request.data.get(viewcode_name,0)  # 获取访问码
-                    if viewcode != r_viewcode:  # cookie中的访问码不等于文集访问码，跳转到访问码认证界面
-                        return Response({'code':3})
 
             # 获取文档内容
             try:
-                doc = Doc.objects.get(id=int(doc_id), status=1)
+                doc = Doc.objects.get(id=int(doc_id), top_doc=project.id, status=1)
                 if doc_format == 'json':
                     serializer = DocSerializer(doc)
                     resp = {'code':0,'data':serializer.data}
@@ -489,7 +465,7 @@ class DocView(APIView):
                     return render(request,'app_api/single_doc_detail.html',locals())
                 else:
                     logger.info(doc_format)
-            except ObjectDoesNotExist:
+            except (ValueError, ObjectDoesNotExist):
                 return Response({'code':4})
         # 不存在文集ID和文档ID，返回用户自己的文档列表
         else:

--- a/app_doc/tests.py
+++ b/app_doc/tests.py
@@ -1,3 +1,59 @@
+from django.contrib.auth.models import AnonymousUser, User
 from django.test import TestCase
+from django.test.client import RequestFactory
 
-# Create your tests here.
+from app_doc.models import Doc, Project
+from app_doc.views import check_viewcode, get_pro_doc, get_pro_doc_tree
+
+
+class ProjectAnonymousPermissionTest(TestCase):
+    def setUp(self):
+        self.factory = RequestFactory()
+        self.owner = User.objects.create_user(username='owner', password='password')
+        self.private_project = Project.objects.create(
+            name='private project',
+            intro='private project',
+            role=1,
+            create_user=self.owner,
+        )
+        self.private_doc = Doc.objects.create(
+            name='secret doc',
+            pre_content='secret',
+            content='secret content',
+            top_doc=self.private_project.id,
+            create_user=self.owner,
+        )
+
+    def test_get_pro_doc_rejects_anonymous_private_project(self):
+        request = self.factory.post('/get_pro_doc/', {'pro_id': self.private_project.id})
+        request.user = AnonymousUser()
+
+        response = get_pro_doc(request)
+
+        self.assertJSONEqual(
+            response.content,
+            {'status': False, 'data': '无权访问'},
+        )
+
+    def test_get_pro_doc_tree_rejects_anonymous_private_project(self):
+        request = self.factory.post('/get_pro_doc_tree/', {'pro_id': self.private_project.id})
+        request.user = AnonymousUser()
+
+        response = get_pro_doc_tree(request)
+
+        self.assertJSONEqual(
+            response.content,
+            {'status': False, 'data': '无权访问'},
+        )
+
+    def test_check_viewcode_does_not_render_private_project_name(self):
+        request = self.factory.get(
+            '/check_viewcode/',
+            {'to': '/project/{}/'.format(self.private_project.id)},
+        )
+        request.user = AnonymousUser()
+
+        response = check_viewcode(request)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertNotContains(response, self.private_project.name)

--- a/app_doc/utils.py
+++ b/app_doc/utils.py
@@ -11,6 +11,66 @@ import io
 import subprocess
 import shutil
 
+
+def get_project_role_users(role_value):
+    if not role_value:
+        return []
+    return [i.strip() for i in str(role_value).split(',') if i.strip()]
+
+
+def is_project_role_user(user, role_value):
+    return user.is_authenticated and user.username in get_project_role_users(role_value)
+
+
+def is_project_privileged_user(user, project):
+    if not user.is_authenticated:
+        return False
+    if user == project.create_user:
+        return True
+    return ProjectCollaborator.objects.filter(project=project, user=user).exists()
+
+
+def get_request_project_viewcode(request, project):
+    viewcode_name = 'viewcode-{}'.format(project.id)
+    request_cookies = getattr(request, 'COOKIES', {})
+    if viewcode_name in request_cookies:
+        return request_cookies.get(viewcode_name)
+
+    request_data = getattr(request, 'data', None)
+    if request_data is not None:
+        viewcode = request_data.get(viewcode_name, None)
+        if viewcode is not None:
+            return viewcode
+
+    query_params = getattr(request, 'query_params', None)
+    if query_params is not None:
+        viewcode = query_params.get(viewcode_name, None)
+        if viewcode is not None:
+            return viewcode
+
+    request_post = getattr(request, 'POST', {})
+    return request_post.get(viewcode_name, None)
+
+
+def can_view_project(request, project):
+    user = getattr(request, 'user', None)
+    if user is None:
+        return project.role == 0
+    if project.role == 0:
+        return True
+    if is_project_privileged_user(user, project):
+        return True
+    if project.role == 1:
+        return False
+    if project.role == 2:
+        return is_project_role_user(user, project.role_value)
+    if project.role == 3:
+        return project.role_value == get_request_project_viewcode(request, project)
+    if project.role == 4:
+        return user.is_authenticated
+    return False
+
+
 # 编辑模式与图标class映射
 EDITOR_MODE_ICON_MAP = {
     1:'iconfont mrdoc-icon-wendang',

--- a/app_doc/views.py
+++ b/app_doc/views.py
@@ -22,7 +22,7 @@ from django.utils.translation import gettext_lazy as _
 from loguru import logger
 from app_api.serializers_app import *
 from app_doc.report_utils import *
-from app_doc.utils import check_user_project_writer_role, EDITOR_MODE_ICON_MAP
+from app_doc.utils import can_view_project, check_user_project_writer_role, EDITOR_MODE_ICON_MAP
 from app_admin.models import UserOptions,SysSetting
 from app_admin.decorators import check_headers,allow_report_file
 from app_admin.utils import is_zip_bomb
@@ -550,6 +550,8 @@ def check_viewcode(request):
             if project_id:
                 project_id = project_id.group(1)
             project = Project.objects.get(id=int(project_id))
+            if project.role != 3:
+                return render(request,'404.html')
             return render(request,'app_doc/check_viewcode.html',locals())
         else:
             viewcode = request.POST.get('viewcode','')
@@ -2066,6 +2068,12 @@ def get_doctemp(request):
 def get_pro_doc(request):
     pro_id = request.POST.get('pro_id','')
     if pro_id != '':
+        try:
+            project = Project.objects.get(id=int(pro_id))
+        except (ValueError, ObjectDoesNotExist):
+            return JsonResponse({'status':False,'data':_('参数错误')})
+        if not can_view_project(request, project):
+            return JsonResponse({'status':False,'data':_('无权访问')})
         # 获取文集所有文档的id、name和parent_doc3个字段
         doc_list = Doc.objects.filter(top_doc=int(pro_id),status=1).values_list('id','name','parent_doc').order_by('parent_doc')
         item_list = []
@@ -2142,6 +2150,12 @@ def get_pro_doc_tree(request):
     pro_id = request.POST.get('pro_id', None)
     is_page = request.POST.get('is_page', False)
     if pro_id:
+        try:
+            project = Project.objects.get(id=int(pro_id))
+        except (ValueError, ObjectDoesNotExist):
+            return JsonResponse({'status':False,'data':_('参数错误')})
+        if not can_view_project(request, project):
+            return JsonResponse({'status':False,'data':_('无权访问')})
         # 查询存在上级文档的文档
         parent_id_list = Doc.objects.filter(top_doc=pro_id,status=1).exclude(parent_doc=0).values_list('parent_doc',flat=True)
         # 获取存在上级文档的上级文档ID


### PR DESCRIPTION
## Summary

This PR adds project-level permission checks before returning project document metadata from currently exposed `app_doc` endpoints.

Changes include:

- Add a shared `can_view_project()` helper for project visibility checks.
- Check project access before returning data from `/get_pro_doc/`.
- Check project access before returning data from `/get_pro_doc_tree/`.
- Avoid rendering the view-code page for non-view-code projects.
- Add a defense-in-depth `pid`/`did` ownership check in `app_api.views_app.DocView`.

## Background

Commit `90c10f7` already fixed the unused `/api_app/` sensitive field exposure by removing `role_value` from `ProjectSerializer` and disabling the related `/api_app/*` routes.

This PR addresses a separate issue in the still-exposed `app_doc` routes: unauthenticated users could submit a `pro_id` to document tree/list endpoints and obtain metadata for private or access-code projects.

The exposed data is metadata rather than document body content, such as document IDs, titles, hierarchy, and modify time.

## Security Impact

This prevents unauthorized enumeration of private/access-code project document structure through:

- `POST /get_pro_doc/`
- `POST /get_pro_doc_tree/`

It also adds a defensive ownership check for `/api_app/docs/` in case those API routes are restored in the future.

## Tests

Added regression tests for:

- Anonymous access to private project document list.
- Anonymous access to private project document tree.
- View-code page not rendering private project info for non-view-code projects.
- `did` must belong to requested `pid` in `DocView`.

Note: I could not run the test suite locally because the local environment is missing `haystack`.
