### PR TITLE
fix: prevent document modification permission bypass

### DIFF
--- a/app_doc/views.py
+++ b/app_doc/views.py
@@ -1243,7 +1243,9 @@ def modify_doc(request,doc_id):
                 doc = Doc.objects.get(id=doc_id)
                 if doc.editor_mode == 3:
                     doc_content = sanitize_html(doc_content)
-                project = Project.objects.get(id=project_id)
+                project = Project.objects.get(id=doc.top_doc)
+                if int(project_id) != int(project.id):
+                    return JsonResponse({'status': False, 'data': _('Unauthorized request')})
                 pro_colla = ProjectCollaborator.objects.filter(project=project, user=request.user)
                 if pro_colla.count() == 0:
                     is_pro_colla = False


### PR DESCRIPTION
## Summary

本 PR 修复了文档修改接口中的权限绕过问题。

`modify_doc` 的 POST 处理逻辑使用用户可控的 `project` 参数进行权限判断，但实际更新的目标文档由 `doc_id` 决定。普通登录用户可以先创建一个自己的文集，然后在请求中将 `project` 设置为自己的文集 ID，同时将 `doc_id` 设置为其他用户的文档 ID，从而绕过权限校验。

## Impact

普通登录用户在知道目标文档 ID 的情况下，可能越权修改不属于自己的文档。

如果结合文档目录元数据泄露问题，私密文档的 ID 和标题可能被枚举，从而进一步扩大该问题的影响。

## Fix

修改文档时使用文档真实所属文集 `doc.top_doc` 进行权限判断，并拒绝 `project` 参数与文档实际所属文集不一致的请求。



